### PR TITLE
scripting.executeScript: result serialization incompatibility

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -71,7 +71,7 @@ let foo='my result'; foo;
 
 Here the results array contains the string "`my result`" as an element.
 
-The result values must be [structured cloneable](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) (see [Data cloning algorithm](/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#data_cloning_algorithm)).
+The result values must be [structured cloneable](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) in Firefox while [JSON serialization algorithm](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description) is used in Chrome (see [Data cloning algorithm](/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#data_cloning_algorithm) for more details on incompatibilities).
 
 ## Examples
 


### PR DESCRIPTION
### Description

Explicitly say that Firefox and Chrome use different serialization algorithms to pass return value of `scripting.executeScript()` WebExtensions method.

### Motivation

Despite current description of script result has a link to the Chrome incompatibilities page, wording is confusing. The phrase does not suggest that another serialization method is implemented in Chrome. Explicit mention of JSON serialization along with structured clone should warn readers about corner cases.